### PR TITLE
Migrate to new Västtrafik API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 .DS_Store
 env/
+build.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests==2.31.0
+requests>=2.9.1
 tabulate==0.7.5
 wheel==0.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests==2.9.1
+requests==2.31.0
 tabulate==0.7.5
 wheel==0.24.0

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='vtjp',
-    version='0.1.14',
+    version='0.2.1',
     description='Västtrafik API.',
     long_description='Python implementation of Västtrafik Journy planner'
                      '(vtjp) public API.',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description='Västtrafik API.',
     long_description='Python implementation of Västtrafik Journy planner'
                      '(vtjp) public API.',
-    url='https://github.com/persandstrom/python-vasttrafik',
+    url='https://github.com/Miicroo/python-vasttrafik',
     author='Per Sandström',
     author_email='per.j.sandstrom@gmail.com',
     license='MIT',
@@ -24,7 +24,7 @@ setup(
         'Programming Language :: Python :: 3.5',
     ],
     keywords='vasttrafik västtrafik',
-    install_requires=['requests>=2.9.1', 'tabulate>=0.7.5'],
+    install_requires=['requests>=2.31.0', 'tabulate>=0.7.5'],
     packages=['vasttrafik'],
     zip_safe=True,
     entry_points={

--- a/vasttrafik/__main__.py
+++ b/vasttrafik/__main__.py
@@ -76,7 +76,6 @@ def print_trip_table(document):
     table = []
     altnr = 0
     for alternative in document:
-        print(alternative)
         altnr += 1
         first_trip_in_alt = True
         if not isinstance(alternative['tripLegs'], list):

--- a/vasttrafik/journy_planner.py
+++ b/vasttrafik/journy_planner.py
@@ -6,16 +6,17 @@ Västtrafik API
 import base64
 import json
 import requests
+import urllib.parse
 from datetime import datetime
 from datetime import timedelta
 
-TOKEN_URL = 'https://api.vasttrafik.se/token'
-API_BASE_URL = 'https://api.vasttrafik.se/bin/rest.exe/v2'
-DATE_FORMAT = '%Y-%m-%d'
-TIME_FORMAT = '%H:%M'
+TOKEN_URL = 'https://ext-api.vasttrafik.se/token'
+API_BASE_URL = 'https://ext-api.vasttrafik.se/pr/v4'
+
 
 class Error(Exception):
     pass
+
 
 def _get_node(response, *ancestors):
     """ Traverse tree to node """
@@ -26,6 +27,13 @@ def _get_node(response, *ancestors):
         else:
             document = document[ancestor]
     return document
+
+
+def _format_datetime(date: datetime):
+    if date.tzinfo is None:
+        default_tz = datetime.now().astimezone().tzinfo
+        date = date.replace(tzinfo=default_tz)
+    return urllib.parse.quote(date.isoformat())
 
 
 class JournyPlanner:
@@ -43,80 +51,61 @@ class JournyPlanner:
             'Content-Type': 'application/x-www-form-urlencoded',
             'Authorization': 'Basic ' + base64.b64encode(
                 (self._key + ':' + self._secret).encode()).decode()
-            }
+        }
         data = {'grant_type': 'client_credentials'}
 
         response = requests.post(TOKEN_URL, data=data, headers=headers)
         obj = json.loads(response.content.decode('UTF-8'))
         self._token = obj['access_token']
         self._token_expire_date = (
-            datetime.now() +
-            timedelta(minutes=self._expiery))
+                datetime.now() +
+                timedelta(minutes=self._expiery))
 
     # LOCATION
-
-    def location_allstops(self):
-        """ location.allstops """
-        response = self._request(
-            'location.allstops')
-        return _get_node(response, 'LocationList', 'StopLocation')
 
     def location_nearbystops(self, origin_coord_lat, origin_coord_long):
         """ location.nearbystops """
         response = self._request(
-            'location.nearbystops',
-            originCoordLat=origin_coord_lat,
-            originCoordLong=origin_coord_long)
-        return _get_node(response, 'LocationList', 'StopLocation')
-
-    def location_nearbyaddress(self, origin_coord_lat, origin_coord_long):
-        """ location.nearbyaddress """
-        response = self._request(
-            'location.nearbyaddress',
-            originCoordLat=origin_coord_lat,
-            originCoordLong=origin_coord_long)
-        return _get_node(response, 'LocationList', 'CoordLocation')
+            'locations/by-coordinates',
+            latitude=origin_coord_lat,
+            longitude=origin_coord_long)
+        return _get_node(response, 'results')
 
     def location_name(self, name):
         """ location.name """
         response = self._request(
-            'location.name',
-            input=name)
-        return _get_node(response, 'LocationList', 'StopLocation')
+            'locations/by-text',
+            q=name,
+            types='stoparea')
+        return _get_node(response, 'results')
 
     # ARRIVAL BOARD
-
     def arrivalboard(self, stop_id, date=None, direction=None):
         """ arrivalBoard """
         date = date if date else datetime.now()
         request_parameters = {
-            'id': stop_id,
-            'date': date.strftime(DATE_FORMAT),
-            'time': date.strftime(TIME_FORMAT)
+            'startDateTime': _format_datetime(date)
         }
         if direction:
-            request_parameters['directiona'] = direction
+            request_parameters['directionGid'] = direction
         response = self._request(
-            'arrivalBoard',
+            f'stop-areas/{stop_id}/arrivals',
             **request_parameters)
-        return _get_node(response, 'ArrivalBoard', 'Arrival')
+        return _get_node(response, 'results')
 
     # DEPARTURE BOARD
-
     def departureboard(self, stop_id, date=None, direction=None):
         """ departureBoard """
         date = date if date else datetime.now()
         request_parameters = {
-            'id': stop_id,
-            'date': date.strftime(DATE_FORMAT),
-            'time': date.strftime(TIME_FORMAT)
+            'startDateTime': _format_datetime(date)
         }
         if direction:
-            request_parameters['direction'] = direction
+            request_parameters['directionGid'] = direction
         response = self._request(
-            'departureBoard',
+            f'stop-areas/{stop_id}/departures',
             **request_parameters)
-        return _get_node(response, 'DepartureBoard', 'Departure')
+        return _get_node(response, 'results')
 
     # TRIP
 
@@ -124,22 +113,21 @@ class JournyPlanner:
         """ trip """
         date = date if date else datetime.now()
         response = self._request(
-            'trip',
-            originId=origin_id,
-            destId=dest_id,
-            date=date.strftime(DATE_FORMAT),
-            time=date.strftime(TIME_FORMAT))
-        return _get_node(response, 'TripList', 'Trip')
+            'journeys',
+            originGid=origin_id,
+            destinationGid=dest_id,
+            dateTime=_format_datetime(date))
+        return _get_node(response, 'results')
 
     def _request(self, service, **parameters):
         """ request builder """
-        urlformat = "{baseurl}/{service}?{parameters}&format=json"
+        urlformat = "{baseurl}/{service}?{parameters}"
         url = urlformat.format(
             baseurl=API_BASE_URL,
             service=service,
             parameters="&".join([
                 "{}={}".format(key, value) for key, value in parameters.items()
-                ]))
+            ]))
         if datetime.now() > self._token_expire_date:
             self.update_token()
         headers = {'Authorization': 'Bearer ' + self._token}
@@ -148,4 +136,4 @@ class JournyPlanner:
             return json.loads(res.content.decode('UTF-8'))
         else:
             raise Error('Error: ' + str(res.status_code) +
-                            str(res.content))
+                        str(res.content))


### PR DESCRIPTION
Migrated to new Västtrafik API [Planera Resa v4](https://developer.vasttrafik.se/apis/13/v4), using [official migration guide](https://github.com/vasttrafik/api-pr-docs/blob/main/docs/MIGRATION.md). Journey planner now works with the new API, but since it is exposing the raw structures, calling clients will have to be updated to new response objects